### PR TITLE
dict objects should not be a list

### DIFF
--- a/doc/adr/0002-use-meta-yaml-to-track-feedstock-metadata.md
+++ b/doc/adr/0002-use-meta-yaml-to-track-feedstock-metadata.md
@@ -100,7 +100,7 @@ For example:
 
 ```yaml
 recipes:
-  - dict_object: "recipe:all_recipes
+  dict_object: "recipe:all_recipes"
 ```
 
 Rules for this section:


### PR DESCRIPTION
@pangeo-forge-bot uses Pydantic typing to validate `meta.yaml`s (as of opening this PR, the code for this lives in the private repo [pangeo-forge/registrar](https://github.com/pangeo-forge/registrar)).

Typing for the `meta.yaml` recipes section looks like this

```python
class MetaYaml(BaseModel):
    ...
    recipes: Union[List[RecipeObject], RecipeDictObject]
    ...
```

If dict objects are provided as a YAML list in `meta.yaml` (as currently indicated in ADR 2), this causes a validation error, because recipe dict objects should not be a list. This scenario was observed in https://github.com/pangeo-forge/staged-recipes/pull/31#issuecomment-1058307750.

This PR changes ADR 2 to indicate that dict objects should not be passed as a list, but rather a simple mapping.

